### PR TITLE
Use streams instead of threads in Java to use Java 8's prefered parallelism method

### DIFF
--- a/thread-java/Sum.java
+++ b/thread-java/Sum.java
@@ -1,74 +1,23 @@
-import java.util.ArrayList;
-import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Sum performs a number of summations on multiple threads.
  */
-public class Sum implements Runnable {
-    /**
-     * Shared total which the sums will update.
-     */
-    private static int SumOfSums = 0;
-
-    /**
-     * Initializes a Sum with the ending value.
-     */
-    public Sum(int max) {
-        this.max = max;
-        this.sum = 0;
-    }
-
-    /**
-     * @see java.lang.Runnable.run()
-     */
-    public void run() {
-        System.out.println("Starting summation to " + max + "...");
-        sum = 0;
-        for (int i = 0; i <= max; i++) {
-            System.out.print("." + i + ".");
-            sum += i;
-
-            // Artificial delay.
-            try {
-                Thread.sleep(20);
-            } catch(InterruptedException iexc) {
-            }
-        }
-        System.out.println("Summation to " + max + " = " + sum);
-
-        // Increment the sum of sums.
-        synchronized(Sum.class) {
-            SumOfSums += sum;
-        }
-    }
-
-    private int max;
-    private int sum;
-
-    /**
-     * Test driver for Sum.
-     */
-    public static void main(String[] args) {
+public class Sum {
+    public static void main(String[] args) throws InterruptedException {
+        Stream<String> strings = Stream.of(args);
         if (args.length > 0) {
-            List<Thread> threads = new ArrayList<Thread>(args.length);
-            for (String s: args) {
-                threads.add(new Thread(new Sum(Integer.parseInt(s))));
-            }
+            int totalSum = strings.mapToInt(Integer::parseInt) // We want to do operations on integers, not strings
+                    .peek(num -> System.out.println("Starting summation to " + num + "..."))
+                    .parallel() // We want everything to be done in parallel
+                    .map(max -> IntStream.rangeClosed(1, max).sum()) // Perform our summation function on all numbers
+                    .sequential()
+                    .peek(sum -> System.out.println("Summation = " + sum))
+                    .sum(); // Find the total sum and store it in the original int.
+            System.out.println("\nFinal sum of sums = " + totalSum);
 
-            for (Thread t: threads) {
-                t.start();
-            }
-
-            for (Thread t: threads) {
-                try {
-                    t.join();
-                } catch(InterruptedException iexc) {
-                }
-            }
-
-            System.out.println("\nFinal sum of sums = " + SumOfSums);
-        } else {
-            System.out.println("Usage: Sum <int>*");
         }
     }
 }
+


### PR DESCRIPTION
This has a few disadvantages that I was unable to work around while keeping the code small and concise, but it uses the stream's parallelism rather than setting something similar up with Threads (all of that is done behind the scenes). 

This also uses modular arithmetic, which means that when the Integer overflows, it will wrap around to the min value. This could probably use a little bit of extra polish, but as it stands now, it is 100% functional (no pun intended).
