### PR TITLE
Added an error message that indicates when something goes wrong.

### DIFF
--- a/calendar-retriever/calendar-retriever.js
+++ b/calendar-retriever/calendar-retriever.js
@@ -39,6 +39,10 @@ $(function () {
                 $("body").append($("<p></p>")
                     .text("No events were found for that date."));
             }
+        },
+        error: function() {
+            $("body").append($("<p></p>"))
+                .text("The program encountered an error.");
         }
     });
 


### PR DESCRIPTION
The calendar-retriever.js script does not appear to be functional anymore. However, no error message was returned to indicate that something had gone wrong. I added an error message so that the user would have an indication that an error had occurred instead of just being left at a blank screen. This will serve useful until the actual cause of the problem can be found and repaired.
