### PR TITLE
Fixing scaling/rotating in keyframe tweener

### DIFF
--- a/animation-sprite/keyframe-tweener.js
+++ b/animation-sprite/keyframe-tweener.js
@@ -103,7 +103,6 @@
                             renderingContext.rotate(
                                 ease(currentTweenFrame, rotateStart, rotateDistance, duration)
                             );
-
                             renderingContext.scale(
                                 ease(currentTweenFrame, sxStart, sxDistance, duration),
                                 ease(currentTweenFrame, syStart, syDistance, duration)

--- a/animation-sprite/keyframe-tweener.js
+++ b/animation-sprite/keyframe-tweener.js
@@ -100,12 +100,13 @@
                                 ease(currentTweenFrame, txStart, txDistance, duration),
                                 ease(currentTweenFrame, tyStart, tyDistance, duration)
                             );
+                            renderingContext.rotate(
+                                ease(currentTweenFrame, rotateStart, rotateDistance, duration)
+                            );
+
                             renderingContext.scale(
                                 ease(currentTweenFrame, sxStart, sxDistance, duration),
                                 ease(currentTweenFrame, syStart, syDistance, duration)
-                            );
-                            renderingContext.rotate(
-                                ease(currentTweenFrame, rotateStart, rotateDistance, duration)
                             );
 
                             // Draw the sprite.


### PR DESCRIPTION
As it is right now, the keyframe tweener rotates, THEN scales. I think this is incorrect. I want to scale my thing either horizontally or vertically, THEN rotate it. Even though it was coded in that order, it had the opposite effect. Swapping them has the desired effect.